### PR TITLE
fixbug：修复BeepManager的构造方法调用链updatePrefs->buildMediaPlayer-> mediaPlay…

### DIFF
--- a/camera-scan/src/main/java/com/king/camera/scan/manager/BeepManager.java
+++ b/camera-scan/src/main/java/com/king/camera/scan/manager/BeepManager.java
@@ -61,7 +61,18 @@ public final class BeepManager implements MediaPlayer.OnErrorListener, Closeable
 
     private synchronized void updatePrefs() {
         if (mediaPlayer == null) {
-            mediaPlayer = buildMediaPlayer(context);
+            new Thread(() -> {
+                MediaPlayer mp = buildMediaPlayer(context);
+                synchronized (BeepManager.this) {
+                    if (mp != null) {
+                        if (mediaPlayer == null) {
+                            mediaPlayer = mp;
+                        } else {
+                            mp.release();
+                        }
+                    }
+                }
+            }).start();
         }
         if (vibrator == null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {


### PR DESCRIPTION
错误日志堆栈

"main" prio=5 tid=1 Native
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x72364640 self=0xb4000075a388bc00
  | sysTid=32344 nice=-10 cgrp=default sched=0/0 handle=0x762ae674f8
  | state=S schedstat=( 7185475396 386459212 6952 ) utm=648 stm=69 core=7 HZ=100
  | stack=0x7fd33cb000-0x7fd33cd000 stackSize=8192KB
  | held mutexes=
  native: #00 pc 00000000000d6a94  /apex/com.android.runtime/lib64/bionic/libc.so!libc.so (offset 9b000) (__ioctl+4)
  native: #01 pc 00000000000935c4  /apex/com.android.runtime/lib64/bionic/libc.so!libc.so (offset 8a000) (ioctl+156)
  native: #02 pc 0000000000051a7c  /system/lib64/libbinder.so (android::IPCThreadState::talkWithDriver(bool)+296)
  native: #03 pc 0000000000052a68  /system/lib64/libbinder.so (android::IPCThreadState::waitForResponse(android::Parcel*, int*)+60)
  native: #04 pc 00000000000527d8  /system/lib64/libbinder.so (android::IPCThreadState::transact(int, unsigned int, android::Parcel const&, android::Parcel*, unsigned int)+184)
  native: #05 pc 000000000004b01c  /system/lib64/libbinder.so (android::BpBinder::transact(unsigned int, android::Parcel const&, android::Parcel*, unsigned int)+188)
  native: #06 pc 0000000000047378  /system/lib64/libmedia.so (android::BpMediaPlayerService::create(android::sp<android::IMediaPlayerClient> const&, audio_session_t)+580)
  native: #07 pc 000000000003aff8  /system/lib64/libmedia.so (android::MediaPlayer::setDataSource(int, long, long)+252)
  native: #08 pc 000000000006053c  /system/lib64/libmedia_jni.so (android_media_MediaPlayer_setDataSourceFD(_JNIEnv*, _jobject*, _jobject*, long, long)+212)
  at android.media.MediaPlayer._setDataSource(Native method)
  at android.media.MediaPlayer.setDataSource(MediaPlayer.java:1298)
  at com.king.camera.scan.manager.BeepManager.buildMediaPlayer(BeepManager.java:92)
  at com.king.camera.scan.manager.BeepManager.updatePrefs(BeepManager.java:64)
  - locked <0x049613ce> (a com.king.camera.scan.manager.BeepManager)
  at com.king.camera.scan.manager.BeepManager.<init>(BeepManager.java:51)
  at com.king.camera.scan.BaseCameraScan.initData(BaseCameraScan.java:235)
  at com.king.camera.scan.BaseCameraScan.<init>(BaseCameraScan.java:177)
  at com.king.camera.scan.BaseCameraScan.<init>(BaseCameraScan.java:166)
  at com.king.camera.scan.BaseCameraScanActivity.createCameraScan(BaseCameraScanActivity.java:226)
  at com.king.camera.scan.BaseCameraScanActivity.initUI(BaseCameraScanActivity.java:87)
  at com.king.camera.scan.BaseCameraScanActivity.onCreate(BaseCameraScanActivity.java:72)
  at android.app.Activity.performCreate(Activity.java:8311)
  at android.app.Activity.performCreate(Activity.java:8283)
  at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1315)
  at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3710)
  at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3897)
  at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
  at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
  at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
  at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2333)
  at android.os.Handler.dispatchMessage(Handler.java:106)
  at android.os.Looper.loop(Looper.java:237)
  at android.app.ActivityThread.main(ActivityThread.java:8414)
  at java.lang.reflect.Method.invoke(Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:663)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)

修复BeepManager的构造方法调用链，主线程调用导致的anr问题